### PR TITLE
Update set_premium function to admin only

### DIFF
--- a/contracts/src/NameService.ts
+++ b/contracts/src/NameService.ts
@@ -114,7 +114,7 @@ class NameService extends SmartContract {
    *
    */
   @method async register_name(name: Name, record: NameRecord) {
-    this.paused.getAndRequireEquals().assertFalse("zkapp is paused");
+    this.paused.getAndRequireEquals().assertFalse('zkapp is paused');
     let premium = await this.premium_rate();
     const sender = this.sender.getAndRequireSignature();
     const payment_update = AccountUpdate.createSigned(sender);
@@ -136,7 +136,7 @@ class NameService extends SmartContract {
    *
    */
   @method async set_record(name: Name, new_record: NameRecord) {
-    this.paused.getAndRequireEquals().assertFalse("zkapp is paused");
+    this.paused.getAndRequireEquals().assertFalse('zkapp is paused');
     let current_record = (
       await this.offchainState.fields.registry.get(name)
     ).assertSome('this name is not owned');
@@ -159,7 +159,7 @@ class NameService extends SmartContract {
    *
    */
   @method async transfer_name_ownership(name: Name, new_owner: PublicKey) {
-    this.paused.getAndRequireEquals().assertFalse("zkapp is paused");
+    this.paused.getAndRequireEquals().assertFalse('zkapp is paused');
     let current_record = (
       await this.offchainState.fields.registry.get(name)
     ).assertSome('this name is not owned');

--- a/contracts/src/test/NameService.test.ts
+++ b/contracts/src/test/NameService.test.ts
@@ -50,9 +50,21 @@ describe('NameService', () => {
       await setPremiumTx.prove();
       await setPremiumTx.send().wait();
 
-      expect((await name_service_contract.premium_rate()).toString()).not.toEqual('5'); // ensure the premium didn't happen to be 5 before settlement
+      expect(
+        (await name_service_contract.premium_rate()).toString()
+      ).not.toEqual('5'); // ensure the premium didn't happen to be 5 before settlement
       await settle(name_service_contract, sender);
-      expect((await name_service_contract.premium_rate()).toString()).toEqual('5');
+      expect((await name_service_contract.premium_rate()).toString()).toEqual(
+        '5'
+      );
+    });
+    it('fails to set premium if caller is not the admin', async () => {
+      const newPremium = UInt64.from(1);
+      await expect(
+        Mina.transaction({ sender: addresses.user1, fee: 1e5 }, async () => {
+          await name_service_contract.set_premium(newPremium);
+        })
+      ).rejects.toThrow();
     });
   });
 


### PR DESCRIPTION
Fix for admin check and missing event, as specified in the function description. Added test for admin only just in case.